### PR TITLE
Add unit declarator to class and role declarations

### DIFF
--- a/lib/Net/POP3.pm6
+++ b/lib/Net/POP3.pm6
@@ -1,4 +1,4 @@
-class Net::POP3;
+unit class Net::POP3;
 
 use Net::POP3::Raw;
 use Net::POP3::Simple;

--- a/lib/Net/POP3/Message.pm6
+++ b/lib/Net/POP3/Message.pm6
@@ -1,4 +1,4 @@
-class Net::POP3::Message;
+unit class Net::POP3::Message;
 
 has $.pop;
 has $.sid;

--- a/lib/Net/POP3/Raw.pm6
+++ b/lib/Net/POP3/Raw.pm6
@@ -1,4 +1,4 @@
-role Net::POP3::Raw;
+unit role Net::POP3::Raw;
 
 use Digest;
 

--- a/lib/Net/POP3/Simple.pm6
+++ b/lib/Net/POP3/Simple.pm6
@@ -1,4 +1,4 @@
-role Net::POP3::Simple;
+unit role Net::POP3::Simple;
 
 use Net::POP3::Message;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.